### PR TITLE
class constructor fix

### DIFF
--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -110,7 +110,10 @@ class Browser
 
     const OPERATING_SYSTEM_UNKNOWN = 'unknown';
 
-    public function Browser($userAgent = "")
+    /**
+     * Class constructor
+     */
+    public function __construct($userAgent = "")
     {
         $this->reset();
         if ($userAgent != "") {


### PR DESCRIPTION
Class won't properly instantiate on my instance of php5.4+ via public function Browser(). It needs __construct() method instead. This is also backwards compatible.