### PR TITLE
Add support for Playstation browser

### DIFF
--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -3,8 +3,8 @@
 /**
  * File: Browser.php
  * Author: Chris Schuld (http://chrisschuld.com/)
- * Last Modified: July 4th, 2014
- * @version 1.9
+ * Last Modified: July 22nd, 2016
+ * @version 2.0
  * @package PegasusPHP
  *
  * Copyright (C) 2008-2010 Chris Schuld  (chris@chrisschuld.com)
@@ -90,6 +90,7 @@ class Browser
     const BROWSER_GALEON = 'Galeon'; // http://galeon.sourceforge.net/ (DEPRECATED)
     const BROWSER_NETPOSITIVE = 'NetPositive'; // http://en.wikipedia.org/wiki/NetPositive (DEPRECATED)
     const BROWSER_PHOENIX = 'Phoenix'; // http://en.wikipedia.org/wiki/History_of_Mozilla_Firefox (DEPRECATED)
+    const BROWSER_PLAYSTATION = "PlayStation";
 
     const PLATFORM_UNKNOWN = 'unknown';
     const PLATFORM_WINDOWS = 'Windows';
@@ -109,6 +110,7 @@ class Browser
     const PLATFORM_SUNOS = 'SunOS';
     const PLATFORM_OPENSOLARIS = 'OpenSolaris';
     const PLATFORM_ANDROID = 'Android';
+    const PLATFORM_PLAYSTATION = "Sony PlayStation";
 
     const OPERATING_SYSTEM_UNKNOWN = 'unknown';
 
@@ -431,6 +433,7 @@ class Browser
             $this->checkBrowserIceCat() ||
             $this->checkBrowserIceweasel() ||
             $this->checkBrowserW3CValidator() ||
+            $this->checkBrowserPlayStation() ||
             $this->checkBrowserMozilla() /* Mozilla is such an open standard that you must check it last */
         );
     }
@@ -1253,7 +1256,28 @@ class Browser
     }
 
     /**
-     * Determine the user's platform (last updated 1.7)
+     * Determine if the browser is a PlayStation
+     * @return boolean True if the browser is PlayStation otherwise false
+     */
+    protected function checkBrowserPlayStation()
+    {
+        if (stripos($this->_agent, 'PlayStation ') !== false) {
+            $aresult = explode(' ', stristr($this->_agent, 'PlayStation '));
+            $this->setBrowser(self::BROWSER_PLAYSTATION);
+            if (isset($aresult[0])) {
+                $aversion = explode(')', $aresult[2]);
+                $this->setVersion($aversion[0]);
+                if (stripos($this->_agent, 'Portable)') !== false || stripos($this->_agent, 'Vita') !== false) {
+                    $this->setMobile(true);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Determine the user's platform (last updated 2.0)
      */
     protected function checkPlatform()
     {
@@ -1324,6 +1348,10 @@ class Browser
         elseif (stripos($this->_agent, 'win') !== false)
         {
             $this->_platform = self::PLATFORM_WINDOWS;
+        }
+        elseif (stripos($this->_agent, 'Playstation') !== false)
+        {
+            $this->_platform = self::PLATFORM_PLAYSTATION;
         }
 
     }


### PR DESCRIPTION
I'm new to doing things on GitHub so hopefully I did everything right. I saw the issue #44 and thought I'd try to help out. I used the useragent changer in Chrome and I believe it works fine , if anyone has a Playstation please confirm for me. 😀 

Here are the results I got when testing the PS4 useragent:
`Browser = PlayStation`
`Version = 1.000`
`isMobile = false`
`Platform = Sony PlayStation`

Here is the useragent I used (found with Google):
`Mozilla/5.0 (PlayStation 4 1.000) AppleWebKit/536.26 (KHTML, like Gecko)`