### PR TITLE
Enforce using precise distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 php:
   - 7.0
   - 5.6


### PR DESCRIPTION
PHP 5.3 is not supported on trusty distribution. Enforce using precise distribution until End Of Life (which is currently planned for April 1st, 2018)