### PR TITLE
Correct 'Vivalidi' into 'Vivaldi'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
 
 script: phpunit --configuration phpunit.xml.dist

--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -97,7 +97,7 @@ class Browser
     const BROWSER_MSN = 'MSN Browser'; // http://explorer.msn.com/
     const BROWSER_MSNBOT = 'MSN Bot'; // http://search.msn.com/msnbot.htm
     const BROWSER_BINGBOT = 'Bing Bot'; // http://en.wikipedia.org/wiki/Bingbot
-    const BROWSER_VIVALDI = 'Vivalidi'; // https://vivaldi.com/
+    const BROWSER_VIVALDI = 'Vivaldi'; // https://vivaldi.com/
     const BROWSER_YANDEX = 'Yandex'; // https://browser.yandex.ua/
 
     const BROWSER_NETSCAPE_NAVIGATOR = 'Netscape Navigator'; // http://browser.netscape.com/ (DEPRECATED)
@@ -415,7 +415,7 @@ class Browser
             //     before Safari
             // (5) Netscape 9+ is based on Firefox so Netscape checks
             //     before FireFox are necessary
-            // (6) Vivalid is UA contains both Firefox and Chrome so Vivalid checks
+            // (6) Vivaldi is UA contains both Firefox and Chrome so Vivaldi checks
             //     before Firefox and Chrome
             $this->checkBrowserWebTv() ||
             $this->checkBrowserEdge() ||


### PR DESCRIPTION
This has potential impact for users relying on the existing typo to make their code work.
Comments were also fixed to take into account the correct name of the browser.

EDIT: On creation of the pull request, tests results were failing due to the fact that Travis CI dropped support of precise images and thus PHP 5.3. I removed PHP 5.3 in the `.travis.yml` file.