### PR TITLE
Support newer Edge versions

### DIFF
--- a/lib/Browser.php
+++ b/lib/Browser.php
@@ -906,8 +906,8 @@ class Browser
      */
     protected function checkBrowserEdge()
     {
-        if (stripos($this->_agent, 'Edge/') !== false) {
-            $aresult = explode('/', stristr($this->_agent, 'Edge'));
+        if ($name = stripos($this->_agent, 'Edge/') !== false ? 'Edge' : stripos($this->_agent, 'Edg/') !== false ? 'Edg' : false) {
+            $aresult = explode('/', stristr($this->_agent, $name));
             if (isset($aresult[1])) {
                 $aversion = explode(' ', $aresult[1]);
                 $this->setVersion($aversion[0]);


### PR DESCRIPTION
In newer versions of Edge (based on Chrome) the user agent is using the "Edg" code name instead of "Edge".

Example user agent of Edge Version 81.0.416.41 (Official Build) beta (64 bit)
Downloaded from https://www.microsoftedgeinsider.com/
```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.83 Safari/537.36 Edg/81.0.416.41
```

Related issues #89